### PR TITLE
Fix getting home directory.

### DIFF
--- a/utils/ioutils/ioutils.go
+++ b/utils/ioutils/ioutils.go
@@ -547,13 +547,13 @@ func AppendFile(srcPath string, destFile *os.File) error {
 }
 
 func GetHomeDir() string {
-	user, err := user.Current()
-	if err == nil {
-		return user.HomeDir
-	}
 	home := os.Getenv("HOME")
 	if home != "" {
 		return home
+	}
+	user, err := user.Current()
+	if err == nil {
+		return user.HomeDir
 	}
 	return ""
 }


### PR DESCRIPTION
Dear jfrog team,

I got trouble to run jfrog rt config with creating ~/.jfrog/  resulting no login cached.
My coworkers have same UID on central server. Each of them have different HOME which is not default HOME. And they have read only right on default HOME.
I know my linux environment is strange. But still someone can change $HOME which is different from default HOME of /etc/passwd. This case you can't cache login info into ~/.frog/s like me.
You can reproduce it with belows.

``` basn
$ mkdir temp; cd temp
$ export HOME=`pwd`
$ jfrog rt config
```

ioutils' GetHomeDir() returns os.users' Home, not $HOME. So it did not work. I think os.Getenv("HOME") is better way to get current $HOME than user.HomeDir. So I make patch to switch both of them.

If my description is not enough, please contact me.

Thanks,
..Yongkwan Kim