### PR TITLE
Support AQL Sort and Limit

### DIFF
--- a/artifactory/utils/aqlsearchutil.go
+++ b/artifactory/utils/aqlsearchutil.go
@@ -24,21 +24,27 @@ func AqlSearchDefaultReturnFields(specFile *File, flags AqlSearchFlag) ([]AqlSea
 }
 
 func AqlSearchBySpec(specFile *File, flags AqlSearchFlag) ([]AqlSearchResultItem, error) {
-	aqlJson, _ := json.Marshal(specFile.Aql.ItemsFind)
-	sortJson,_ := json.Marshal(specFile.Aql.Sort)
+	aqlJson, err := json.Marshal(specFile.Aql.ItemsFind)
+	if cliutils.CheckError(err) != nil {
+		return nil, err
+	}
+	sortJson, err := json.Marshal(specFile.Aql.Sort)
+	if cliutils.CheckError(err) != nil {
+		return nil, err
+	}
 	aqlBody := string(aqlJson)
 	sort := string(sortJson)
 	limit := specFile.Aql.Limit
 	query := "items.find(" + aqlBody + ")"
 	query += ".include(" + strings.Join(GetDefaultQueryReturnFields(), ",") + ")"
-	if sort != "" {
+	if sort != "" && sort != "null" {
 		query += ".sort(" + sort + ")"
 	}
-	if sort != "" {
+	if limit > 0 {
 		query += ".limit(" + strconv.Itoa(limit) + ")"
 	}
 
-	log.Info("AQL query = " +query)
+	log.Debug("AQL query = " +query)
 
 	results, err := AqlSearch(query, flags)
 	if err != nil {

--- a/artifactory/utils/specUtils.go
+++ b/artifactory/utils/specUtils.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"github.com/jfrogdev/jfrog-cli-go/utils/io/fileutils"
 	"github.com/jfrogdev/jfrog-cli-go/utils/cliutils"
-	"strings"
+	//"strings"
 	"strconv"
 )
 
@@ -15,7 +15,9 @@ const (
 )
 
 type Aql struct {
-	ItemsFind string `json:"items.find"`
+	ItemsFind map[string]interface{} `json:"items.find"`
+	Sort map[string]interface{} `json:"sort"`
+	Limit int `json:"limit"`
 }
 
 type File struct {
@@ -41,14 +43,14 @@ func (spec *SpecFiles) Get(index int) *File {
 	return new(File)
 }
 
-func (aql *Aql) UnmarshalJSON(value []byte) error {
+/*func (aql *Aql) UnmarshalJSON(value []byte) error {
 	str := string(value)
 	first := strings.Index(str[strings.Index(str, "{") + 1 :], "{")
 	last := strings.LastIndex(str, "}")
 
 	aql.ItemsFind = cliutils.StripChars(str[first:last], "\n\t ")
 	return nil
-}
+}*/
 
 func CreateSpecFromFile(specFilePath string) (spec *SpecFiles, err error) {
 	spec = new(SpecFiles)
@@ -88,7 +90,7 @@ func (file File) GetSpecType() (specType SpecType) {
 		specType = WILDCARD
 	case file.Pattern != "":
 		specType = SIMPLE
-	case file.Aql.ItemsFind != "" :
+	case file.Aql.ItemsFind != nil :
 		specType = AQL
 	}
 	return specType

--- a/artifactory/utils/specUtils.go
+++ b/artifactory/utils/specUtils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/jfrogdev/jfrog-cli-go/utils/io/fileutils"
 	"github.com/jfrogdev/jfrog-cli-go/utils/cliutils"
-	//"strings"
 	"strconv"
 )
 
@@ -43,14 +42,6 @@ func (spec *SpecFiles) Get(index int) *File {
 	return new(File)
 }
 
-/*func (aql *Aql) UnmarshalJSON(value []byte) error {
-	str := string(value)
-	first := strings.Index(str[strings.Index(str, "{") + 1 :], "{")
-	last := strings.LastIndex(str, "}")
-
-	aql.ItemsFind = cliutils.StripChars(str[first:last], "\n\t ")
-	return nil
-}*/
 
 func CreateSpecFromFile(specFilePath string) (spec *SpecFiles, err error) {
 	spec = new(SpecFiles)


### PR DESCRIPTION
Added support for AQL sort and limit, for example:
```

{
  "files": [
    {
      "aql": {
        "items.find": {
          "repo": "libs-release-local"
        },
        "sort" : {"$desc" : ["name"]},
        "limit" : 5
      },
      "target": "files"
    }
  ]
}
```