### PR TITLE
Added ciserver-url option to the build-publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ go get github.com/jfrogdev/jfrog-cli-go/jfrog
 ````
 Go will download and build the project on your machine. Once complete, you will find the JFrog CLI executable under your `$GOPATH/bin` directory.
 
+## Build a modified version hosted in another git repo
+- Checkout your repo e.g. to "...\Repos\jfrog-cli-go\src\github.com\jfrogdev\jfrog-cli-go\"
+- Do your modifications.
+- cd into the jfrog dir and do a "go install", this will create a jfrog.exe in "Repos\jfrog-cli-go\bin"
+
+
+
 # Tests
 
 ### Artifactory Integration tests

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -436,6 +436,10 @@ func getBuildPublishFlags() []cli.Flag {
 			Name:  "env-exclude",
 			Usage: "[Default: *password*;*secret*;*key*] List of patterns in the form of \"value1;value2;...\"  environment variables match those patterns will be eccluded.",
 		},
+		cli.StringFlag{
+			Name:  "ciserver-url",
+			Usage: "[Optional] Your CI-Server URL for this build.",
+		},
 	}...)
 }
 
@@ -1106,6 +1110,7 @@ func createBuildInfoFlags(c *cli.Context) (flags *utils.BuildInfoFlags, err erro
 	flags.DryRun = c.Bool("dry-run")
 	flags.EnvInclude = c.String("env-include")
 	flags.EnvExclude = c.String("env-exclude")
+	flags.CiServerUrl = c.String("ciserver-url")
 	if len(flags.EnvInclude) == 0 {
 		flags.EnvInclude = "*"
 	}

--- a/artifactory/commands/buildpublish.go
+++ b/artifactory/commands/buildpublish.go
@@ -84,6 +84,9 @@ func createBuildInfo(buildName, buildNumber string, buildInfoRawData utils.Build
 	}
 	module := createModule(buildName, artifactsSet, dependenciesSet)
 	buildInfo.Modules = append(buildInfo.Modules, module)
+	if (flags.CiServerUrl != "") {
+		buildInfo.CiServerUrl = flags.CiServerUrl
+	}
 	return buildInfo, nil
 }
 
@@ -143,6 +146,7 @@ type BuildInfo struct {
 	Properties  utils.BuildEnv `json:"properties,omitempty"`
 	VcsUrl      string 		   `json:"vcsUrl,omitempty"`
 	VcsRevision string 		   `json:"vcsRevision,omitempty"`
+	CiServerUrl string 		   `json:"url,omitempty"`
 }
 
 type CliAgent struct {

--- a/artifactory/utils/buildutils.go
+++ b/artifactory/utils/buildutils.go
@@ -211,9 +211,10 @@ func RemoveBuildDir(buildName, buildNumber string) error {
 
 type BuildInfoFlags struct {
 	ArtDetails *config.ArtifactoryDetails
-	DryRun     bool
-	EnvInclude string
-	EnvExclude string
+	DryRun      bool
+	EnvInclude  string
+	EnvExclude  string
+	CiServerUrl string
 }
 
 type build struct {


### PR DESCRIPTION
See https://github.com/JFrogDev/jfrog-cli-go/issues/33
I added an option "--ciserver-url" to the "build-publish" command to have a "url" field in the generated buildInfo.json to be shown in the Artifactory "builds" pages.