### PR TITLE
SshAuthentication: ssh-agent support

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1150,6 +1150,9 @@ func createArtifactoryDetails(c *cli.Context, includeConfig bool) (*config.Artif
 		}
 	}
 	details.Url = cliutils.AddTrailingSlashIfNeeded(details.Url)
+	if strings.HasPrefix(details.Url, "ssh://") {
+		details.Ssh = true
+	}
 	return details, nil
 }
 

--- a/artifactory/utils/artifactoryutils.go
+++ b/artifactory/utils/artifactoryutils.go
@@ -112,7 +112,7 @@ func initTransport(artDetails *config.ArtifactoryDetails) (error) {
 }
 
 func PreCommandSetup(flags CommonFlags) (err error) {
-	if flags.GetArtifactoryDetails().SshKeyPath != "" {
+	if flags.GetArtifactoryDetails().Ssh {
 		err = SshAuthentication(flags.GetArtifactoryDetails())
 		if err != nil {
 			return

--- a/artifactory/utils/sshlogin.go
+++ b/artifactory/utils/sshlogin.go
@@ -6,9 +6,12 @@ import (
 	"github.com/jfrogdev/jfrog-cli-go/utils/cliutils"
 	"github.com/jfrogdev/jfrog-cli-go/utils/config"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 	"errors"
 	"io"
 	"io/ioutil"
+	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"github.com/jfrogdev/jfrog-cli-go/utils/cliutils/log"
@@ -21,27 +24,21 @@ func SshAuthentication(details *config.ArtifactoryDetails) error {
 	}
 
 	log.Info("Performing SSH authentication...")
-	if details.SshKeyPath == "" {
-		err := cliutils.CheckError(errors.New("Cannot invoke the SshAuthentication function with no SSH key path. "))
-        if err != nil {
-            return err
-        }
+
+	var sshAuth ssh.AuthMethod
+	if details.SshKeyPath != "" {
+		sshAuth, err = PublicKeyFile(details.SshKeyPath)
+	} else {
+		sshAuth, err = SSHAgent()
+	}
+	if err != nil {
+		return err
 	}
 
-	buffer, err := ioutil.ReadFile(details.SshKeyPath)
-	err = cliutils.CheckError(err)
-	if err != nil {
-	    return err
-	}
-	key, err := ssh.ParsePrivateKey(buffer)
-	err = cliutils.CheckError(err)
-	if err != nil {
-	    return err
-	}
 	sshConfig := &ssh.ClientConfig{
 		User: "admin",
 		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(key),
+			sshAuth,
 		},
 		HostKeyCallback : ssh.InsecureIgnoreHostKey(),
 	}
@@ -122,4 +119,26 @@ func parseUrl(url string) (protocol, host string, port int, err error) {
 type SshAuthResult struct {
 	Href    string
 	Headers map[string]string
+}
+
+func PublicKeyFile(file string) (ssh.AuthMethod, error) {
+	buffer, err := ioutil.ReadFile(file)
+	err = cliutils.CheckError(err)
+	if err != nil {
+		return nil, err
+	}
+	key, err := ssh.ParsePrivateKey(buffer)
+	err = cliutils.CheckError(err)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.PublicKeys(key), nil
+}
+
+func SSHAgent() (ssh.AuthMethod, error) {
+	sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+	if err != nil {
+		return nil, err
+	}
+	return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers), nil
 }

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -280,6 +280,7 @@ type ArtifactoryDetails struct {
 	User           string            `json:"user,omitempty"`
 	Password       string            `json:"password,omitempty"`
 	ApiKey         string            `json:"apiKey,omitempty"`
+	Ssh	           bool              `json:"ssh,omitempty"`
 	SshKeyPath     string            `json:"sshKeyPath,omitempty"`
 	ServerId       string            `json:"serverId,omitempty"`
 	IsDefault      bool              `json:"isDefault,omitempty"`


### PR DESCRIPTION
The proper condition to perform ssh authentication is that Artifactory URL starts with "ssh://".
And if --ssh-key-path is omitted, try to use ssh-agent.