### PR TITLE
fix a thread hang issue.

### DIFF
--- a/vendor/github.com/gofrog/parallel/runner.go
+++ b/vendor/github.com/gofrog/parallel/runner.go
@@ -135,6 +135,7 @@ func (r *runner) Done() {
 	select {
 	case <-r.cancel:
 	//Already canceled
+		close(r.tasks)
 	default:
 		close(r.tasks)
 	}


### PR DESCRIPTION
if a problem occurred in one thread, and fail fast is on, cancel function will be executed, if thread num is more than 2 and producer is still keeping add task into the runner in a loop, then in addTask function, the channel ”cancel“ is always selectable because it has been closed, producer will got return value "-1" and message "runner stopped", but jfrog-client does not care it, after the loop finished, defer done will be executed and producer exit, but no one to close the channel "tasks", and other threads is waiting tasks from it, wg can not be reduced to 0, then program will print nothing to the console, it's looks like a deadlock. Add a close action in "Done" function will make sure channel "tasks" will be closed and other threads can break from foreach loop, and error will be printed to the console.