### PR TITLE
Add build-add-artifact command to support adding priorly uploaded artifacts to build info

### DIFF
--- a/jfrog-cli/artifactory/cli.go
+++ b/jfrog-cli/artifactory/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/artifactory/utils"
 	goutils "github.com/jfrogdev/jfrog-cli-go/jfrog-cli/artifactory/utils/golang"
 	npmutils "github.com/jfrogdev/jfrog-cli-go/jfrog-cli/artifactory/utils/npm"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/docs/artifactory/buildaddartifact"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/docs/artifactory/buildadddependencies"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/docs/artifactory/buildaddgit"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/docs/artifactory/buildclean"
@@ -264,6 +265,18 @@ func GetCommands() []cli.Command {
 			ArgsUsage: common.CreateEnvVars(),
 			Action: func(c *cli.Context) {
 				buildDistributeCmd(c)
+			},
+		},
+		{
+			Name:      "build-add-artifact",
+			Flags:     getServerFlags(),
+			Aliases:   []string{"baa"},
+			Usage:     buildaddartifact.Description,
+			HelpName:  common.CreateUsage("rt build-add-artifact", buildaddartifact.Description, buildaddartifact.Usage),
+			UsageText: buildaddartifact.Arguments,
+			ArgsUsage: common.CreateEnvVars(),
+			Action: func(c *cli.Context) {
+				buildAddArtifactCmd(c)
 			},
 		},
 		{
@@ -1502,6 +1515,15 @@ func buildDistributeCmd(c *cli.Context) {
 	cliutils.ExitOnErr(err)
 }
 
+func buildAddArtifactCmd(c *cli.Context) {
+	if c.NArg() != 3 {
+		cliutils.PrintHelpAndExitWithError("Wrong number of arguments.", c)
+	}
+	configuration := createBuildAddArtifactConfiguration(c)
+	err := buildinfo.AddArtifact(configuration)
+	cliutils.ExitOnErr(err)
+}
+
 func gitLfsCleanCmd(c *cli.Context) {
 	if c.NArg() > 1 {
 		cliutils.PrintHelpAndExitWithError("Wrong number of arguments.", c)
@@ -1779,6 +1801,15 @@ func createBuildDistributionConfiguration(c *cli.Context) (distributeConfigurati
 	distributeConfiguration.BuildName = c.Args().Get(0)
 	distributeConfiguration.BuildNumber = c.Args().Get(1)
 	distributeConfiguration.TargetRepo = c.Args().Get(2)
+	return
+}
+
+func createBuildAddArtifactConfiguration(c *cli.Context) (addArtifactConfiguration *buildinfo.BuildAddArtifactConfiguration) {
+	addArtifactConfiguration = new(buildinfo.BuildAddArtifactConfiguration)
+	addArtifactConfiguration.ArtDetails = createArtifactoryDetailsByFlags(c, true)
+	addArtifactConfiguration.Artifact = c.Args().Get(2)
+	addArtifactConfiguration.BuildName = c.Args().Get(0)
+	addArtifactConfiguration.BuildNumber = c.Args().Get(1)
 	return
 }
 

--- a/jfrog-cli/artifactory/commands/buildinfo/addartifact.go
+++ b/jfrog-cli/artifactory/commands/buildinfo/addartifact.go
@@ -1,0 +1,42 @@
+package buildinfo
+
+import (
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/artifactory/utils"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/utils/config"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/log"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/artifactory/buildinfo"
+)
+
+func AddArtifact(flags *BuildAddArtifactConfiguration) (err error) {
+	log.Info("Adding artifact '" + flags.Artifact + "' to build info " + flags.BuildName + " #" + flags.BuildNumber + "...")
+
+	err = utils.SaveBuildGeneralDetails(flags.BuildName, flags.BuildNumber); if err != nil {
+		return
+	}
+
+	serviceManager, err := utils.CreateServiceManager(flags.ArtDetails, false); if err != nil {
+		return err
+	}
+
+	fileInfo, err := serviceManager.GetFileInfo(flags.Artifact); if err != nil {
+		return err
+	}
+
+	buildArtifacts := []buildinfo.InternalArtifact{fileInfo.ToBuildArtifact()}
+	populateFunc := func(partial *buildinfo.Partial) {
+		partial.Artifacts = buildArtifacts
+	}
+	err = utils.SavePartialBuildInfo(flags.BuildName, flags.BuildNumber, populateFunc); if err != nil {
+		return
+	}
+
+	log.Info("Successfully added artifact to build info")
+	return
+}
+
+type BuildAddArtifactConfiguration struct {
+	ArtDetails  *config.ArtifactoryDetails
+	Artifact    string
+	BuildName   string
+	BuildNumber string
+}

--- a/jfrog-cli/artifactory/commands/generic/upload.go
+++ b/jfrog-cli/artifactory/commands/generic/upload.go
@@ -11,9 +11,7 @@ import (
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/log"
 	"os"
 	"strconv"
-	"strings"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/artifactory/spec"
-	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/io/fileutils"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/artifactory/buildinfo"
 )
 
@@ -40,9 +38,6 @@ func Upload(uploadSpec *spec.SpecFiles, flags *UploadConfiguration) (successCoun
 	if isCollectBuildInfo && !flags.DryRun {
 		if err := utils.SaveBuildGeneralDetails(flags.BuildName, flags.BuildNumber); err != nil {
 			return 0, 0, err
-		}
-		for i := 0; i < len(uploadSpec.Files); i++ {
-			addBuildProps(&uploadSpec.Get(i).Props, flags.BuildName, flags.BuildNumber)
 		}
 	}
 
@@ -98,15 +93,10 @@ func Upload(uploadSpec *spec.SpecFiles, flags *UploadConfiguration) (successCoun
 	return
 }
 
-func convertFileInfoToBuildArtifacts(filesInfo []clientutils.FileInfo) []buildinfo.Artifact {
-	buildArtifacts := make([]buildinfo.Artifact, len(filesInfo))
+func convertFileInfoToBuildArtifacts(filesInfo []clientutils.FileInfo) []buildinfo.InternalArtifact {
+	buildArtifacts := make([]buildinfo.InternalArtifact, len(filesInfo))
 	for i, fileInfo := range filesInfo {
-		artifact := buildinfo.Artifact{Checksum: &buildinfo.Checksum{}}
-		artifact.Sha1 = fileInfo.Sha1
-		artifact.Md5 = fileInfo.Md5
-		filename, _ := fileutils.GetFileAndDirFromPath(fileInfo.LocalPath)
-		artifact.Name = filename
-		buildArtifacts[i] = artifact
+		buildArtifacts[i] = fileInfo.ToBuildArtifact()
 	}
 	return buildArtifacts
 }
@@ -145,22 +135,6 @@ func getMinChecksumDeploySize() (int64, error) {
 		return 0, err
 	}
 	return minSize * 1000, nil
-}
-
-func addBuildProps(props *string, buildName, buildNumber string) error {
-	if buildName == "" || buildNumber == "" {
-		return nil
-	}
-	buildProps, err := utils.CreateBuildProperties(buildName, buildNumber)
-	if err != nil {
-		return err
-	}
-
-	if len(*props) > 0 && !strings.HasSuffix(*props, ";") && len(buildProps) > 0 {
-		*props += ";"
-	}
-	*props += buildProps
-	return nil
 }
 
 type UploadConfiguration struct {

--- a/jfrog-cli/artifactory/commands/npm/publish.go
+++ b/jfrog-cli/artifactory/commands/npm/publish.go
@@ -161,9 +161,9 @@ func (npmp *npmPublish) doDeploy(target string, artDetails *config.ArtifactoryDe
 
 func (npmp *npmPublish) saveArtifactData() error {
 	log.Debug("Saving npm package artifact build info data.")
-	var buildArtifacts []buildinfo.Artifact
+	var buildArtifacts []buildinfo.InternalArtifact
 	for _, artifact := range npmp.artifactData {
-		buildArtifacts = append(buildArtifacts, artifact.ToBuildArtifacts())
+		buildArtifacts = append(buildArtifacts, artifact.ToBuildArtifact())
 	}
 
 	populateFunc := func(partial *buildinfo.Partial) {

--- a/jfrog-cli/docs/artifactory/buildaddartifact/help.go
+++ b/jfrog-cli/docs/artifactory/buildaddartifact/help.go
@@ -1,0 +1,15 @@
+package buildaddartifact
+
+const Description = "This command is used to add a priorly uploaded artifact to a build."
+
+var Usage = []string{"jfrog rt baa [command options] <build name> <build number> <artifact>"}
+
+const Arguments string =
+`	build name
+		Build name.
+
+	build number
+		Build number.
+
+	artifact
+		Existing artifact to add to build, specified as <repo-key>/<file-path>.`

--- a/jfrog-client/artifactory/buildinfo/buildinfo.go
+++ b/jfrog-client/artifactory/buildinfo/buildinfo.go
@@ -3,6 +3,7 @@ package buildinfo
 import (
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-cli/utils/cliutils"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/artifactory/auth"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/io/fileutils"
 	"time"
 )
 
@@ -67,15 +68,26 @@ type Vcs struct {
 	Revision string `json:"vcsRevision,omitempty"`
 }
 
+type InternalArtifact struct {
+	Path string `json:"Path,omitempty"`
+	*Checksum
+}
+
+func (internalArtifact *InternalArtifact) ToArtifact() Artifact {
+	artifact := Artifact{Checksum: internalArtifact.Checksum}
+	artifact.Name, _ = fileutils.GetFileAndDirFromPath(internalArtifact.Path)
+	return artifact
+}
+
 type Partials []*Partial
 
 type Partial struct {
-	Artifacts    []Artifact   `json:"Artifacts,omitempty"`
-	Dependencies []Dependency `json:"Dependencies,omitempty"`
-	Env          Env          `json:"Env,omitempty"`
-	Timestamp    int64        `json:"Timestamp,omitempty"`
+	Artifacts       []InternalArtifact `json:"Artifacts,omitempty"`
+	Dependencies    []Dependency       `json:"Dependencies,omitempty"`
+	Env          	Env                `json:"Env,omitempty"`
+	Timestamp    	int64              `json:"Timestamp,omitempty"`
 	*Vcs
-	ModuleId     string       `json:"ModuleId,omitempty"`
+	ModuleId     	string             `json:"ModuleId,omitempty"`
 }
 
 func (partials Partials) Len() int {

--- a/jfrog-client/artifactory/manager.go
+++ b/jfrog-client/artifactory/manager.go
@@ -144,6 +144,12 @@ func (sm *ArtifactoryServicesManager) PublishVgoProject(params vgo.VgoParams) er
 	return vgoService.PublishPackage(params)
 }
 
+func (sm *ArtifactoryServicesManager) GetFileInfo(path string) (*utils.FileInfo, error) {
+	getFileInfoService := services.NewFileInfoService(sm.client)
+	getFileInfoService.ArtDetails = sm.config.GetArtDetails()
+	return getFileInfoService.GetFileInfo(path)
+}
+
 func (sm *ArtifactoryServicesManager) setCommonServiceConfig(commonConfig ArtifactoryServicesSetter) {
 	commonConfig.SetThread(sm.config.GetThreads())
 	commonConfig.SetArtDetails(sm.config.GetArtDetails())

--- a/jfrog-client/artifactory/services/fileinfo.go
+++ b/jfrog-client/artifactory/services/fileinfo.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/artifactory/auth"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/httpclient"
+	clientutils "github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils"
+	rtclientutils "github.com/jfrogdev/jfrog-cli-go/jfrog-client/artifactory/services/utils"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/errorutils"
+	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/log"
+)
+
+type getFileInfoService struct {
+	client     *httpclient.HttpClient
+	ArtDetails auth.ArtifactoryDetails
+}
+
+func NewFileInfoService(client *httpclient.HttpClient) *getFileInfoService {
+	return &getFileInfoService{client: client}
+}
+
+func (gfi *getFileInfoService) GetArtifactoryDetails() auth.ArtifactoryDetails {
+	return gfi.ArtDetails
+}
+
+func (gfi *getFileInfoService) SetArtifactoryDetails(rt auth.ArtifactoryDetails) {
+	gfi.ArtDetails = rt
+}
+
+func (gfi *getFileInfoService) GetFileInfo(path string) (fileInfo *rtclientutils.FileInfo, err error) {
+	getFileInfoUrl := gfi.ArtDetails.GetUrl() + "api/storage/" + path
+	log.Debug("Retrieving file info through URL: " + getFileInfoUrl)
+	httpClientsDetails := gfi.GetArtifactoryDetails().CreateHttpClientDetails()
+	resp, body, _, err := gfi.client.SendGet(getFileInfoUrl, true, httpClientsDetails); if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, errorutils.CheckError(errors.New("Error retrieving file info; Artifactory response: " + resp.Status + "\n" + clientutils.IndentJson(body)))
+	}
+
+	log.Debug("Artifactory response:", resp.Status)
+
+	var result fileInfoResult
+	err = json.Unmarshal(body, &result)
+	if errorutils.CheckError(err) != nil {
+		return nil, err
+	}
+
+	if len(result.Children) > 0 {
+		return nil, errorutils.CheckError(errors.New("Artifact has children; this is currently not supported"))
+	}
+
+	fileInfo = new(rtclientutils.FileInfo)
+	fileInfo.ArtifactoryPath = path
+	fileInfo.FileHashes = new(rtclientutils.FileHashes)
+	*fileInfo.FileHashes = result.Checksums
+
+	log.Debug("Successfully retrieved file info:\n" +
+	          "  path            = " + fileInfo.ArtifactoryPath + "\n" +
+	          "  Sha1 checksum   = " + fileInfo.FileHashes.Sha1 + "\n" +
+	          "  Sha256 checksum = " + fileInfo.FileHashes.Sha256 + "\n" +
+	          "  Md5 checksum    = " + fileInfo.FileHashes.Md5)
+	return
+}
+
+type fileInfoResult struct {
+	Path        string
+	Checksums   rtclientutils.FileHashes
+	Children    []map[string]interface{}
+}

--- a/jfrog-client/artifactory/services/utils/fileinfoutils.go
+++ b/jfrog-client/artifactory/services/utils/fileinfoutils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/utils/io/fileutils"
 	"github.com/jfrogdev/jfrog-cli-go/jfrog-client/artifactory/buildinfo"
 )
 
@@ -17,11 +16,10 @@ type FileInfo struct {
 	ArtifactoryPath string `json:"artifactoryPath,omitempty"`
 }
 
-func (fileInfo *FileInfo) ToBuildArtifacts() buildinfo.Artifact {
-	artifact := buildinfo.Artifact{Checksum: &buildinfo.Checksum{}}
+func (fileInfo *FileInfo) ToBuildArtifact() buildinfo.InternalArtifact {
+	artifact := buildinfo.InternalArtifact{Checksum: &buildinfo.Checksum{}}
 	artifact.Sha1 = fileInfo.Sha1
 	artifact.Md5 = fileInfo.Md5
-	filename, _ := fileutils.GetFileAndDirFromPath(fileInfo.LocalPath)
-	artifact.Name = filename
+	artifact.Path = fileInfo.ArtifactoryPath
 	return artifact
 }


### PR DESCRIPTION
In case one uploads artifacts by other means than the JFrog CLI while
wanting to leverage JFrog CLI to upload builds, the build-add-artifact
command allows one to add priorly uploaded artifacts to the local
build info.

When publishing that build, these artifacts get tagged with the build
name and -number.

For the sake of consistency, artifacts uploaded by means of the
upload command will also only get tagged when the build is published.

Notes:
* This PR is work-in-progress. I still need to add support for spec files, add new tests and update existing tests. Before proceeding, I'd like to get some feedback on the WIP.
* This PR is the continuation of [PR-77](https://github.com/JFrogDev/jfrog-cli-go/pull/77), which I'll close in a bit.